### PR TITLE
Change the URL to download the dependency in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Adds [Rework](https://github.com/visionmedia/rework) support to [brunch](http://
 
 ## Usage
 
-Add `"rework-brunch": "git+ssh://git@github.com:bolasblack/rework-brunch.git"` to your `package.json`.
+Add `"rework-brunch": "git@github.com:bolasblack/rework-brunch.git"` to your `package.json` (in the "dependencies" section).
 
 ### Options
 


### PR DESCRIPTION
For an unknown reason, I couldn't download the package from the URL which was proposed in the README.
